### PR TITLE
Add PagerApter behavior to WizardPagerSettings

### DIFF
--- a/library/src/main/java/com/atech/android/library/wizardpager/WizardPagerActivity.java
+++ b/library/src/main/java/com/atech/android/library/wizardpager/WizardPagerActivity.java
@@ -85,7 +85,7 @@ public class WizardPagerActivity extends FragmentActivity implements
 
         //this.onTouchEvent(this)
 
-        mPagerAdapter = new MyPagerAdapter(getSupportFragmentManager(), mWizardModel);
+        mPagerAdapter = new MyPagerAdapter(getSupportFragmentManager(), wizardPagerSettings.getPagerAdapterBehavior(), mWizardModel);
         mPager = findViewById(R.id.pager);
         mPager.setAdapter(mPagerAdapter);
         mStepPagerStrip = (StepPagerStrip) findViewById(R.id.strip);
@@ -320,8 +320,8 @@ public class WizardPagerActivity extends FragmentActivity implements
 
         AbstractWizardModel wizardModel;
 
-        public MyPagerAdapter(FragmentManager fm, AbstractWizardModel wizardModel) {
-            super(fm);
+        public MyPagerAdapter(FragmentManager fm, int pagerAdapterBehavior, AbstractWizardModel wizardModel) {
+            super(fm, pagerAdapterBehavior);
             this.wizardModel = wizardModel;
         }
 

--- a/library/src/main/java/com/atech/android/library/wizardpager/data/WizardPagerSettings.java
+++ b/library/src/main/java/com/atech/android/library/wizardpager/data/WizardPagerSettings.java
@@ -3,6 +3,7 @@ package com.atech.android.library.wizardpager.data;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 import com.atech.android.library.wizardpager.defs.WizardStepsWayType;
 import com.atech.android.library.wizardpager.defs.action.AbstractCancelAction;
@@ -14,6 +15,7 @@ import com.tech.freak.wizardpager.R;
 public class WizardPagerSettings {
 
     private WizardStepsWayType wizardStepWay = WizardStepsWayType.PreviousNext;
+    private int pagerAdapterBehavior = FragmentStatePagerAdapter.BEHAVIOR_SET_USER_VISIBLE_HINT;
 
     private FinishActionInterface finishAction;
     private CancelActionInterface cancelAction;
@@ -115,5 +117,17 @@ public class WizardPagerSettings {
 
     public void setTheme(int theme) {
         this.theme = theme;
+    }
+
+    public int getPagerAdapterBehavior() {
+        return pagerAdapterBehavior;
+    }
+
+    /**
+     * @param pagerAdapterBehavior the behavior for the FragmentStatePagerAdapter; defaults to
+     *                             FragmentStatePagerAdapter.BEHAVIOR_SET_USER_VISIBLE_HINT
+     */
+    public void setPagerAdapterBehavior(int pagerAdapterBehavior) {
+        this.pagerAdapterBehavior = pagerAdapterBehavior;
     }
 }


### PR DESCRIPTION
Add PagerApter behavior to WizardPagerSettings. Allows to change the FragmentStatePagerAdapter behavior to something other than the default, deprecated behavior.